### PR TITLE
Add Docker support with optional GPU acceleration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+venv/
+env/
+__pycache__/
+*.pyc
+*.log
+.git/
+.github/
+.vscode/
+.idea/
+essentia_models/
+test/
+tmp/
+*.md
+LICENSE
+.gitignore
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN uv pip install --system --no-cache mutagen numpy
 # Download ML models at build time
 COPY download_models.sh .
 ENV HOME=/app
-RUN bash download_models.sh
+RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh
 
 # Copy application code
 COPY tag_music.py .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install Python dependencies
+# essentia-tensorflow only publishes dev builds for Python 3.10+,
+# which are not matched by the >=2.1b6 specifier in requirements.txt,
+# so we install it explicitly first then the remaining deps.
+RUN pip install --no-cache-dir essentia-tensorflow
 COPY requirements.txt .
-RUN pip install --no-cache-dir --pre -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Download ML models at build time
 COPY download_models.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV HOME=/app
 RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh
 
 # Copy application code
-COPY tag_music.py .
+COPY tag_music.py docker-entrypoint.py ./
 
 # Suppress noisy TensorFlow logs (INFO + WARNING)
 ENV TF_CPP_MIN_LOG_LEVEL=3
@@ -42,5 +42,5 @@ ENV TF_CPP_MIN_LOG_LEVEL=3
 # Music directory mount point
 VOLUME ["/music"]
 
-ENTRYPOINT ["python", "tag_music.py", "--model-dir", "/app/essentia_models"]
+ENTRYPOINT ["python", "docker-entrypoint.py", "--model-dir", "/app/essentia_models"]
 CMD ["/music", "--auto"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ COPY tag_music.py .
 # Music directory mount point
 VOLUME ["/music"]
 
-ENTRYPOINT ["python", "tag_music.py"]
-CMD ["/music", "--auto", "--model-dir", "/app/essentia_models"]
+ENTRYPOINT ["python", "tag_music.py", "--model-dir", "/app/essentia_models"]
+CMD ["/music", "--auto"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # so we install it explicitly first then the remaining deps.
 RUN uv pip install --system --no-cache essentia-tensorflow
 COPY requirements.txt .
-RUN uv pip install --system --no-cache -r requirements.txt
+RUN uv pip install --system --no-cache mutagen numpy
 
 # Download ML models at build time
 COPY download_models.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.10-slim
+
+# Install system dependencies required by Essentia
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libfftw3-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libswresample-dev \
+        libsamplerate0-dev \
+        libtag1-dev \
+        libchromaprint-dev \
+        libyaml-dev \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Download ML models at build time
+COPY download_models.sh .
+ENV HOME=/app
+RUN bash download_models.sh
+
+# Copy application code
+COPY tag_music.py .
+
+# Default model directory inside the container
+ENV MODEL_DIR=/app/essentia_models
+
+# Music directory mount point
+VOLUME ["/music"]
+
+ENTRYPOINT ["python", "tag_music.py"]
+CMD ["/music", "--auto"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Install uv for fast dependency management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 # Install Python dependencies
 # essentia-tensorflow only publishes dev builds for Python 3.10+,
 # which are not matched by the >=2.1b6 specifier in requirements.txt,
 # so we install it explicitly first then the remaining deps.
-RUN pip install --no-cache-dir essentia-tensorflow
+RUN uv pip install --system --no-cache essentia-tensorflow
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --system --no-cache -r requirements.txt
 
 # Download ML models at build time
 COPY download_models.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,8 @@ RUN bash download_models.sh
 # Copy application code
 COPY tag_music.py .
 
-# Default model directory inside the container
-ENV MODEL_DIR=/app/essentia_models
-
 # Music directory mount point
 VOLUME ["/music"]
 
 ENTRYPOINT ["python", "tag_music.py"]
-CMD ["/music", "--auto"]
+CMD ["/music", "--auto", "--model-dir", "/app/essentia_models"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 # Install Python dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --pre -r requirements.txt
 
 # Download ML models at build time
 COPY download_models.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh
 # Copy application code
 COPY tag_music.py .
 
+# Suppress noisy TensorFlow logs (INFO + WARNING)
+ENV TF_CPP_MIN_LOG_LEVEL=3
+
 # Music directory mount point
 VOLUME ["/music"]
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,56 @@
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python 3.10 and system dependencies required by Essentia
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.10 \
+        python3.10-venv \
+        python3.10-dev \
+        build-essential \
+        libfftw3-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libswresample-dev \
+        libsamplerate0-dev \
+        libtag1-dev \
+        libchromaprint-dev \
+        libyaml-dev \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python3.10 the default python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
+    && python -m ensurepip --upgrade
+
+WORKDIR /app
+
+# Install uv for fast dependency management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Install Python dependencies
+RUN uv pip install --system --no-cache essentia-tensorflow
+COPY requirements.txt .
+RUN uv pip install --system --no-cache mutagen numpy
+
+# Download ML models at build time
+COPY download_models.sh .
+ENV HOME=/app
+RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh
+
+# Copy application code
+COPY tag_music.py docker-entrypoint.py ./
+
+# Suppress noisy TensorFlow logs (INFO + WARNING)
+ENV TF_CPP_MIN_LOG_LEVEL=3
+
+# Music directory mount point
+VOLUME ["/music"]
+
+ENTRYPOINT ["python", "docker-entrypoint.py", "--model-dir", "/app/essentia_models"]
+CMD ["/music", "--auto"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,16 +1,12 @@
-FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
-# Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python 3.10 and system dependencies required by Essentia
+# Install Python 3.10 (default on Ubuntu 22.04) and system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends \
-        python3.10 \
-        python3.10-venv \
-        python3.10-dev \
+        python3 \
+        python3-pip \
+        python3-dev \
         build-essential \
         libfftw3-dev \
         libavcodec-dev \
@@ -22,11 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libchromaprint-dev \
         libyaml-dev \
         wget \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
-
-# Make python3.10 the default python
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
-    && python -m ensurepip --upgrade
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger /music/song.fla
 
 ### GPU mode (NVIDIA)
 
-Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host.
+Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host. Uses a dedicated `Dockerfile.gpu` based on `nvidia/cuda` with CUDA 11.2 + cuDNN 8 for actual GPU acceleration.
 
 ```bash
-# Build the image
+# Build the GPU image
 docker compose build essentia-tagger-gpu
 
 # Process with GPU acceleration
 MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger-gpu
 ```
 
-If no GPU is available on the host, use the CPU profile instead. TensorFlow inside the container will automatically use the GPU when one is detected, and fall back to CPU otherwise.
+If no GPU is available on the host, use the CPU profile instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Analyze your music collection using machine learning and write accurate genre an
 - 💾 **FLAC & MP3 support** - Writes to standard tag formats
 - 🧪 **Dry run mode** - Test before making changes
 - 🚀 **CPU-only** - No GPU required (though it helps!)
+- 🐳 **Docker support** - Run with Docker, with optional GPU acceleration
 - 🤖 **Automation support** - CLI arguments for scripted/automated workflows
 - 🔄 **Picard integration** - Auto-tag files saved by MusicBrainz Picard.
 
@@ -100,6 +101,40 @@ You'll be prompted for:
 **Recommendation:** Run in dry-run mode first to preview results!
 
 ---
+## 🐳 Docker
+
+### CPU mode
+
+```bash
+# Build the image
+docker compose build essentia-tagger
+
+# Process a music directory
+MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger
+
+# Dry run
+MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger /music --auto --dry-run
+
+# Process a single file
+MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger /music/song.flac --auto --single-file
+```
+
+### GPU mode (NVIDIA)
+
+Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host.
+
+```bash
+# Build the image
+docker compose build essentia-tagger-gpu
+
+# Process with GPU acceleration
+MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger-gpu
+```
+
+If no GPU is available on the host, use the CPU profile instead. TensorFlow inside the container will automatically use the GPU when one is detected, and fall back to CPU otherwise.
+
+---
+
 ## 🤖 Command Line / Automation Mode
 
 For scripting or integration with other tools, use CLI arguments:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,13 @@ services:
     profiles: ["cpu"]
 
   essentia-tagger-gpu:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
     volumes:
       - ${MUSIC_DIR:-./music}:/music
+    networks:
+      - essentia_net
     deploy:
       resources:
         reservations:
@@ -21,3 +25,7 @@ services:
               count: all
               capabilities: [gpu]
     profiles: ["gpu"]
+
+networks:
+  essentia_net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  essentia-tagger:
+    build: .
+    volumes:
+      - ${MUSIC_DIR:-./music}:/music
+    # Override CMD via environment or command
+    # Examples:
+    #   docker compose run essentia-tagger /music --auto --dry-run
+    #   docker compose run essentia-tagger /music/song.flac --auto --single-file
+    profiles: ["cpu"]
+
+  essentia-tagger-gpu:
+    build: .
+    volumes:
+      - ${MUSIC_DIR:-./music}:/music
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    profiles: ["gpu"]

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,0 +1,7 @@
+"""Docker entrypoint that suppresses noisy Essentia warnings before running the tagger."""
+import essentia.log
+essentia.log.warningActive = False
+essentia.log.infoActive = False
+
+import runpy
+runpy.run_path("tag_music.py", run_name="__main__")

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,5 +1,5 @@
 """Docker entrypoint that suppresses noisy Essentia warnings before running the tagger."""
-import essentia.log
+import essentia
 essentia.log.warningActive = False
 essentia.log.infoActive = False
 


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` (CPU) and `Dockerfile.gpu` (NVIDIA CUDA 11.8 + cuDNN 8) for containerized usage
- `docker-compose.yml` with CPU and GPU profiles
- ML models are downloaded at build time so the image is self-contained
- Uses [uv](https://github.com/astral-sh/uv) for fast dependency installation
- Noisy TensorFlow and Essentia warnings suppressed for clean output
- README updated with Docker usage instructions

## Motivation

The program currently only runs on Linux (Debian/Ubuntu). On Windows, `essentia-tensorflow` does not install natively, making Docker the only viable way to run the tagger on Windows machines.

## Usage

```bash
# CPU
MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger

# GPU (requires NVIDIA Container Toolkit)
MUSIC_DIR=/path/to/music docker compose run --rm essentia-tagger-gpu
```

On Windows (PowerShell):
```powershell
$env:MUSIC_DIR="D:\path\to\music"; docker compose run --rm essentia-tagger-gpu /music --auto
```

## Test plan
- [x] Image builds successfully (both CPU and GPU)
- [x] Models download correctly at build time (CRLF line endings handled)
- [x] App starts, loads all 400 genre + 56 mood classes
- [x] Dry run completes without errors
- [x] GPU fully working — all CUDA/cuDNN libraries loaded, RTX 3090 registered by TensorFlow
- [x] Tested on Windows 11 with Docker Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)