### PR TITLE
Feat/rb tagging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV HOME=/app
 RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh
 
 # Copy application code
-COPY tag_music.py docker-entrypoint.py ./
+COPY tag_music.py docker-entrypoint.py riff_info.py comment_merge.py ./
 
 # Suppress noisy TensorFlow logs (INFO + WARNING)
 ENV TF_CPP_MIN_LOG_LEVEL=3

--- a/comment_merge.py
+++ b/comment_merge.py
@@ -1,0 +1,110 @@
+"""
+Comment merging utilities for mood tagging.
+
+Mood tags are written into the standard "comment" field of audio files so they
+appear in DJ software like Rekordbox, which has no native "Mood" field. To
+coexist with other tools that also write to the comment field (notably Mixed
+In Key, which prepends a prefix like "Energy 7 - 8A -"), mood data is wrapped
+in a bracketed marker that can be reliably found and replaced on re-runs.
+
+Format
+------
+Plain:
+    [MOOD: Happy; Energetic; Uplifting]
+With confidence percentages:
+    [MOOD: Happy 87%; Energetic 72%; Uplifting 65%]
+
+Behaviour
+---------
+The marker is appended to the end of the existing comment, separated by a
+single space. On re-runs, any prior [MOOD: ...] block in the comment is
+stripped before the new one is appended, so the comment never accumulates
+stale mood data. The semicolon separator inside the brackets matches the
+existing convention used elsewhere in this project for genre lists.
+
+Known limitation
+----------------
+A user who hand-writes "[MOOD: ...]" as part of their own free-form comment
+will have it overwritten on the next analysis run. The marker is reserved.
+"""
+
+import re
+from typing import List, Optional, Sequence
+
+
+# Matches the [MOOD: ...] marker plus any surrounding whitespace, so that
+# stripping it on a re-run leaves no awkward gaps. Case-insensitive so that
+# hand-edited or older variants (e.g. lowercase "mood:") also get cleaned up.
+# `[^\]]*` matches the inner contents up to the closing bracket -- the marker
+# itself never contains a literal `]`.
+MOOD_MARKER_RE = re.compile(r'\s*\[MOOD:[^\]]*\]\s*', re.IGNORECASE)
+
+
+def build_mood_marker(items: Sequence[str],
+                      confidences: Optional[Sequence[float]] = None) -> str:
+    """Build a bracketed mood marker string.
+
+    Args:
+        items: Pre-formatted mood label strings (e.g. ['Happy', 'Energetic']).
+            Formatting (capitalisation, etc.) is the caller's responsibility;
+            this function does not transform the labels.
+        confidences: Optional parallel sequence of confidences in [0, 1].
+            When provided, each label is suffixed with a rounded percentage
+            (e.g. 'Happy 87%').
+
+    Returns:
+        A string like '[MOOD: Happy; Energetic]' or
+        '[MOOD: Happy 87%; Energetic 72%]'. Returns an empty string if
+        `items` is empty.
+
+    Raises:
+        ValueError: if `confidences` is provided but has a different length
+            than `items`.
+    """
+    if not items:
+        return ''
+    if confidences is not None:
+        if len(confidences) != len(items):
+            raise ValueError(
+                "items and confidences must be the same length "
+                f"(got {len(items)} and {len(confidences)})"
+            )
+        parts: List[str] = [
+            f"{label} {round(conf * 100)}%"
+            for label, conf in zip(items, confidences)
+        ]
+    else:
+        parts = list(items)
+    return f"[MOOD: {'; '.join(parts)}]"
+
+
+def merge_mood_into_comment(existing_comment: Optional[str],
+                            mood_marker: str) -> str:
+    """Strip any prior [MOOD: ...] block from the comment and append a new one.
+
+    The function is safe to call repeatedly: running it twice with the same
+    `mood_marker` is idempotent. It also coexists with tools that prepend
+    their own data to the comment (like Mixed In Key), because the mood
+    marker is always appended as a suffix and only the [MOOD: ...] block
+    itself is touched.
+
+    Args:
+        existing_comment: The current comment text (may be None or empty).
+        mood_marker: The marker to append, typically the output of
+            `build_mood_marker()`. If empty, the function just strips any
+            prior marker and returns the cleaned comment.
+
+    Returns:
+        The comment with any prior mood marker removed and the new marker
+        appended. Whitespace is normalised so that adjacent markers or
+        unusual spacing don't leave double spaces behind.
+    """
+    cleaned = MOOD_MARKER_RE.sub(' ', existing_comment or '')
+    # Collapse any runs of whitespace produced by the substitution and trim
+    # the ends in one pass.
+    cleaned = ' '.join(cleaned.split())
+    if not mood_marker:
+        return cleaned
+    if not cleaned:
+        return mood_marker
+    return f"{cleaned} {mood_marker}"

--- a/riff_info.py
+++ b/riff_info.py
@@ -35,6 +35,28 @@ def _validate_riff_wave(data, label=''):
         raise ValueError(f"Not a RIFF WAVE file{': ' + label if label else ''}")
 
 
+def _validate_wav_structure(data, label=''):
+    """Walk every top-level RIFF chunk and raise ValueError if any chunk
+    declares a size that would extend past the end of the file.
+
+    Called by update_riff_info before making any changes.  A malformed or
+    unusual chunk layout is caught here so the file is never touched.
+    """
+    _validate_riff_wave(data, label)
+    pos = 12
+    while pos + 8 <= len(data):
+        fourcc = data[pos:pos + 4]
+        size = struct.unpack_from('<I', data, pos + 4)[0]
+        if pos + 8 + size > len(data):
+            name = fourcc.decode('latin-1', errors='replace')
+            suffix = f' in {label}' if label else ''
+            raise ValueError(
+                f"WAV chunk '{name}' at offset {pos} declares size {size} "
+                f"but only {len(data) - pos - 8} bytes remain{suffix}"
+            )
+        pos += 8 + size + (size % 2)
+
+
 def _parse_riff_info(data):
     """Return {fourcc_bytes: str} from the first LIST/INFO chunk in *data*.
 
@@ -126,7 +148,7 @@ def update_riff_info(filepath, updates):
     """
     path = Path(filepath)
     data = path.read_bytes()
-    _validate_riff_wave(data, str(filepath))
+    _validate_wav_structure(data, str(filepath))
 
     # Normalise key types to bytes
     norm = {(k.encode('ascii') if isinstance(k, str) else k): v

--- a/riff_info.py
+++ b/riff_info.py
@@ -165,6 +165,13 @@ def update_riff_info(filepath, updates):
         start, end = loc
         new_data = data[:start] + new_list + data[end:]
     else:
+        # If the file ends at an odd offset, the last existing chunk omitted
+        # its spec-required pad byte (legal for the final chunk only).  Add
+        # the pad byte before our new chunk so downstream chunk-walkers,
+        # which advance by `8 + size + (size % 2)`, land on the correct
+        # offset for the LIST INFO chunk we're about to append.
+        if len(data) % 2 != 0:
+            data = data + b'\x00'
         new_data = data + new_list
 
     # Fix RIFF size header (excludes the 8-byte 'RIFF'+size header itself)

--- a/riff_info.py
+++ b/riff_info.py
@@ -1,0 +1,152 @@
+"""Read and write RIFF INFO (LIST/INFO) chunks in WAV files.
+
+RIFF/WAV structure:
+  b'RIFF' <4:LE-uint32 size>  b'WAVE'
+    chunk ...
+    b'LIST' <4:LE-uint32 size>  b'INFO'
+      b'ICMT' <4:LE-uint32 sub-size>  <null-terminated text, padded to even>
+      ...
+    chunk ...
+
+The RIFF size field = total_file_size - 8 (excludes the 8-byte RIFF header).
+INFO sub-chunk size = length of data including null terminator.
+If that length is odd a single silent padding byte follows on disk (not
+counted in the size field).
+
+Encoding: RIFF INFO conventionally uses Windows Latin-1 (cp1252).  ASCII
+mood markers and genre strings encode correctly; non-ASCII characters in
+existing tags are decoded with replacement rather than raising an error.
+"""
+import struct
+from pathlib import Path
+
+_RIFF = b'RIFF'
+_WAVE = b'WAVE'
+_LIST = b'LIST'
+_INFO = b'INFO'
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _validate_riff_wave(data, label=''):
+    if len(data) < 12 or data[:4] != _RIFF or data[8:12] != _WAVE:
+        raise ValueError(f"Not a RIFF WAVE file{': ' + label if label else ''}")
+
+
+def _parse_riff_info(data):
+    """Return {fourcc_bytes: str} from the first LIST/INFO chunk in *data*.
+
+    *data* must already be validated as a RIFF WAVE file.
+    Returns an empty dict when no LIST/INFO chunk is present.
+    """
+    pos = 12
+    while pos + 8 <= len(data):
+        fourcc = data[pos:pos + 4]
+        size = struct.unpack_from('<I', data, pos + 4)[0]
+        content_start = pos + 8
+        content_end = content_start + size
+
+        if fourcc == _LIST and data[content_start:content_start + 4] == _INFO:
+            result = {}
+            sub_pos = content_start + 4
+            while sub_pos + 8 <= content_end:
+                sub_fourcc = data[sub_pos:sub_pos + 4]
+                sub_size = struct.unpack_from('<I', data, sub_pos + 4)[0]
+                raw = data[sub_pos + 8:sub_pos + 8 + sub_size]
+                null_idx = raw.find(b'\x00')
+                if null_idx >= 0:
+                    raw = raw[:null_idx]
+                result[sub_fourcc] = raw.decode('latin-1', errors='replace')
+                # advance past subchunk + padding
+                sub_pos += 8 + sub_size + (sub_size % 2)
+            return result
+
+        # advance past chunk + padding
+        pos += 8 + size + (size % 2)
+
+    return {}
+
+
+def _encode_subchunk(fourcc, text):
+    """Encode one INFO sub-chunk: FOURCC + LE-size + null-terminated value + pad."""
+    value = text.encode('latin-1', errors='replace') + b'\x00'
+    chunk = fourcc + struct.pack('<I', len(value)) + value
+    if len(value) % 2 != 0:
+        chunk += b'\x00'    # silent pad byte; not reflected in size
+    return chunk
+
+
+def _build_list_info(info_dict):
+    """Build a complete LIST/INFO chunk from {fourcc_bytes: str}."""
+    body = _INFO + b''.join(_encode_subchunk(k, v) for k, v in info_dict.items())
+    return _LIST + struct.pack('<I', len(body)) + body
+
+
+def _locate_list_info(data):
+    """Return (start, end) byte offsets of the first LIST/INFO chunk, or None."""
+    pos = 12
+    while pos + 8 <= len(data):
+        fourcc = data[pos:pos + 4]
+        size = struct.unpack_from('<I', data, pos + 4)[0]
+        content_start = pos + 8
+        pad = size % 2
+        end = content_start + size + pad
+
+        if fourcc == _LIST and data[content_start:content_start + 4] == _INFO:
+            return pos, end
+
+        pos = end
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def read_riff_info(filepath):
+    """Return {fourcc_bytes: str} for every sub-chunk in the WAV's LIST/INFO block.
+
+    Returns an empty dict when no LIST/INFO chunk is present.
+    Raises ValueError when the file is not a RIFF WAVE.
+    """
+    data = Path(filepath).read_bytes()
+    _validate_riff_wave(data, str(filepath))
+    return _parse_riff_info(data)
+
+
+def update_riff_info(filepath, updates):
+    """Update or insert RIFF INFO sub-chunks in a WAV file in-place.
+
+    *updates* maps FOURCC keys (bytes or 4-char str) to str values.
+    Existing INFO sub-chunks not present in *updates* are preserved unchanged.
+    Raises ValueError when the file is not a RIFF WAVE.
+    """
+    path = Path(filepath)
+    data = path.read_bytes()
+    _validate_riff_wave(data, str(filepath))
+
+    # Normalise key types to bytes
+    norm = {(k.encode('ascii') if isinstance(k, str) else k): v
+            for k, v in updates.items()}
+
+    # Merge: existing keys not in updates are preserved
+    merged = dict(_parse_riff_info(data))
+    merged.update(norm)
+
+    new_list = _build_list_info(merged)
+
+    loc = _locate_list_info(data)
+    if loc is not None:
+        start, end = loc
+        new_data = data[:start] + new_list + data[end:]
+    else:
+        new_data = data + new_list
+
+    # Fix RIFF size header (excludes the 8-byte 'RIFF'+size header itself)
+    riff_size = len(new_data) - 8
+    new_data = new_data[:4] + struct.pack('<I', riff_size) + new_data[8:]
+
+    path.write_bytes(new_data)

--- a/tag_music.py
+++ b/tag_music.py
@@ -27,6 +27,8 @@ from mutagen.musepack import Musepack
 from mutagen.apev2 import APEv2
 from mutagen.asf import ASF
 
+from comment_merge import build_mood_marker, merge_mood_into_comment
+
 # Supported audio file extensions
 # Analysis: all formats Essentia MonoLoader can decode (via FFmpeg)
 # Tag writing: each format uses an appropriate tag writer
@@ -181,6 +183,7 @@ Analysis Mode: {mode_label}
   - Verbose output: {config.verbose}
   - Parallel workers: {config.workers}
   - Max audio duration: {int(config.max_audio_duration) if config.max_audio_duration < float('inf') else 'unlimited'}s
+  - Rekordbox-compatible mood writing: {config.rb_write}
 {'=' * 80}
 
 """
@@ -304,6 +307,10 @@ class Config:
         self.default_library_path = None
         self.workers = max(1, (os.cpu_count() or 2) // 2)
         self.max_audio_duration = 300  # seconds — cap audio sent to TF models
+        # Rekordbox-compatible writing: append mood as a [MOOD: ...] marker
+        # inside the standard "comment" field instead of (or in addition to)
+        # a custom-description COMM/MOOD tag. See comment_merge.py for details.
+        self.rb_write = False
 
 
 class EssentiaAnalyzer:
@@ -706,15 +713,53 @@ class TagWriter:
                 self.logger.log("     ⏭️  Skipping genres (already has GENRE tag)")
         
         if self.config.enable_moods and results.get('formatted_moods'):
-            mood_str = '; '.join(results['formatted_moods'][:3])
-            tags.add(COMM(
-                encoding=3,
-                lang='eng',
-                desc='Essentia Mood',
-                text=mood_str
-            ))
-            tags_written.append(f"COMM(mood)={mood_str}")
-        
+            if self.config.rb_write:
+                # Rekordbox-compatible path: append a [MOOD: ...] marker to
+                # the standard (empty-description) Comments field. We read
+                # the current comment text first, run it through the merge
+                # function (which strips any prior marker and appends the
+                # new one), then write it back. This preserves Mixed In Key
+                # output and any user comments while keeping mood data
+                # visible in Rekordbox.
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_comm = tags.get('COMM::eng')
+                existing_text = ''
+                if existing_comm is not None and existing_comm.text:
+                    existing_text = existing_comm.text[0]
+
+                new_text = merge_mood_into_comment(
+                    existing_text, mood_marker
+                )
+                tags.delall('COMM::eng')
+                tags.add(COMM(
+                    encoding=3,
+                    lang='eng',
+                    desc='',
+                    text=new_text,
+                ))
+                tags_written.append(f"COMM={new_text}")
+            else:
+                # Original behaviour: write to a custom-description COMM
+                # frame. Not visible in Rekordbox but preserved for
+                # Mp3tag / foobar2000 / etc.
+                mood_str = '; '.join(results['formatted_moods'][:3])
+                tags.add(COMM(
+                    encoding=3,
+                    lang='eng',
+                    desc='Essentia Mood',
+                    text=mood_str
+                ))
+                tags_written.append(f"COMM(mood)={mood_str}")
+
         if tags_written:
             self.logger.log(f"     ✅ Written tags: {', '.join(tags_written)}", console=False)
     
@@ -1608,6 +1653,21 @@ def configure_settings():
     print("   • Overwrite: Replace existing tags")
     print("   • Skip: Leave files with existing tags untouched")
     config.overwrite_existing = get_yes_no("Overwrite existing tags?", default=False)
+
+    # Rekordbox-compatible writing
+    if config.enable_moods:
+        print("\n" + "─" * 70)
+        print("🎛️  REKORDBOX-COMPATIBLE MOOD WRITING")
+        print("   Rekordbox has no native Mood field, so the standard MOOD")
+        print("   tag is invisible there. With this option enabled, mood is")
+        print("   appended to the file's Comments field as a marker:")
+        print("     [MOOD: Happy; Energetic; Uplifting]")
+        print("   This shows up in Rekordbox's Comments column and coexists")
+        print("   with Mixed In Key's Energy/Key prefix.")
+        print("   Currently affects MP3 / AIFF / DSF only.")
+        config.rb_write = get_yes_no(
+            "Enable Rekordbox-compatible mood writing?", default=False
+        )
     
     # Verbose output
     print("\n" + "─" * 70)
@@ -1667,6 +1727,7 @@ def display_config_summary(config, music_path):
     print(f"   • Overwrite existing: {config.overwrite_existing}")
     print(f"   • Verbose output: {config.verbose}")
     print(f"   • Parallel workers: {config.workers}")
+    print(f"   • Rekordbox-compatible mood writing: {config.rb_write}")
     if config.max_audio_duration < float('inf'):
         print(f"   • Max audio duration: {int(config.max_audio_duration)}s")
     else:
@@ -1856,7 +1917,19 @@ Genre format styles:
         metavar='SECS',
         help='Max seconds of audio to analyze per track (default: 300, 0 = no limit)'
     )
-    
+
+    parser.add_argument(
+        '--rb-write',
+        action='store_true',
+        help=(
+            'Rekordbox-compatible mood writing: append mood as a '
+            '[MOOD: ...] marker inside the standard Comments field so it is '
+            'visible in Rekordbox. Coexists with Mixed In Key output. '
+            'Currently affects MP3/AIFF/DSF (ID3) only; other formats follow '
+            'in subsequent work.'
+        )
+    )
+
     return parser.parse_args()
 
 
@@ -1880,6 +1953,7 @@ def config_from_args(args):
     config.genre_format = args.genre_format
     config.workers = args.workers if args.workers > 0 else max(1, (os.cpu_count() or 2) // 2)
     config.max_audio_duration = args.max_duration if args.max_duration > 0 else float('inf')
+    config.rb_write = args.rb_write
     
     # Handle library path
     if args.library:

--- a/tag_music.py
+++ b/tag_music.py
@@ -562,11 +562,33 @@ class TagWriter:
                 self.logger.log("     ⏭️  Skipping genres (already has GENRE tag)")
         
         if self.config.enable_moods and results.get('formatted_moods'):
-            if self.config.overwrite_existing or 'MOOD' not in audio:
+            if self.config.rb_write:
+                # Rekordbox-compatible path: merge a [MOOD: ...] marker into
+                # the standard Vorbis COMMENT field so it shows up in
+                # Rekordbox's Comments column. Coexists with Mixed In Key.
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_text = ''
+                if 'COMMENT' in audio and audio['COMMENT']:
+                    existing_text = audio['COMMENT'][0]
+                new_text = merge_mood_into_comment(
+                    existing_text, mood_marker
+                )
+                audio['COMMENT'] = new_text
+                tags_written.append(f"COMMENT={new_text}")
+            elif self.config.overwrite_existing or 'MOOD' not in audio:
                 mood_str = '; '.join(results['formatted_moods'][:3])
                 audio['MOOD'] = mood_str
                 tags_written.append(f"MOOD={mood_str}")
-                
+
                 if self.config.write_confidence_tags and results.get('moods'):
                     mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
                     mood_conf_str = ', '.join(mood_details)
@@ -574,7 +596,7 @@ class TagWriter:
                     tags_written.append(f"ESSENTIA_MOOD={mood_conf_str}")
             else:
                 self.logger.log("     ⏭️  Skipping moods (already has MOOD tag)")
-        
+
         return tags_written
     
     def _write_ogg(self, filepath, results):
@@ -608,25 +630,58 @@ class TagWriter:
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
                     confidence_str = ', '.join(genre_details)
-                    audio['\xa9cmt'] = [f"Essentia Genre: {confidence_str}"]
-                    tags_written.append(f"comment(genre)={confidence_str}")
+                    # Use a custom iTunes freeform atom rather than \xa9cmt
+                    # (the user's main Comments field). The previous code
+                    # clobbered any existing comment on every run.
+                    audio['----:com.apple.iTunes:Essentia Genre'] = [
+                        mutagen.mp4.MP4FreeForm(
+                            confidence_str.encode('utf-8'),
+                            dataformat=mutagen.mp4.AtomDataType.UTF8,
+                        )
+                    ]
+                    tags_written.append(f"Essentia Genre={confidence_str}")
             else:
                 self.logger.log("     ⏭️  Skipping genres (already has genre tag)")
         
         if self.config.enable_moods and results.get('formatted_moods'):
-            mood_str = '; '.join(results['formatted_moods'][:3])
-            audio['----:com.apple.iTunes:MOOD'] = [
-                mutagen.mp4.MP4FreeForm(mood_str.encode('utf-8'), dataformat=mutagen.mp4.AtomDataType.UTF8)
-            ]
-            tags_written.append(f"MOOD={mood_str}")
-            
-            if self.config.write_confidence_tags and results.get('moods'):
-                mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
-                mood_conf_str = ', '.join(mood_details)
-                audio['----:com.apple.iTunes:ESSENTIA_MOOD'] = [
-                    mutagen.mp4.MP4FreeForm(mood_conf_str.encode('utf-8'), dataformat=mutagen.mp4.AtomDataType.UTF8)
+            if self.config.rb_write:
+                # Rekordbox-compatible path: merge a [MOOD: ...] marker
+                # into the standard MP4 comment atom (\xa9cmt). Coexists
+                # with Mixed In Key.
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_text = ''
+                if audio.tags and '\xa9cmt' in audio.tags:
+                    cmt = audio.tags['\xa9cmt']
+                    if cmt:
+                        existing_text = str(cmt[0])
+                new_text = merge_mood_into_comment(
+                    existing_text, mood_marker
+                )
+                audio['\xa9cmt'] = [new_text]
+                tags_written.append(f"comment={new_text}")
+            else:
+                mood_str = '; '.join(results['formatted_moods'][:3])
+                audio['----:com.apple.iTunes:MOOD'] = [
+                    mutagen.mp4.MP4FreeForm(mood_str.encode('utf-8'), dataformat=mutagen.mp4.AtomDataType.UTF8)
                 ]
-                tags_written.append(f"ESSENTIA_MOOD={mood_conf_str}")
+                tags_written.append(f"MOOD={mood_str}")
+
+                if self.config.write_confidence_tags and results.get('moods'):
+                    mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
+                    mood_conf_str = ', '.join(mood_details)
+                    audio['----:com.apple.iTunes:ESSENTIA_MOOD'] = [
+                        mutagen.mp4.MP4FreeForm(mood_conf_str.encode('utf-8'), dataformat=mutagen.mp4.AtomDataType.UTF8)
+                    ]
+                    tags_written.append(f"ESSENTIA_MOOD={mood_conf_str}")
         
         if tags_written:
             audio.save()
@@ -653,15 +708,39 @@ class TagWriter:
                 self.logger.log("     ⏭️  Skipping genres (already has genre tag)")
         
         if self.config.enable_moods and results.get('formatted_moods'):
-            mood_str = '; '.join(results['formatted_moods'][:3])
-            audio['WM/Mood'] = mood_str
-            tags_written.append(f"WM/Mood={mood_str}")
-            
-            if self.config.write_confidence_tags and results.get('moods'):
-                mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
-                mood_conf_str = ', '.join(mood_details)
-                audio['ESSENTIA_MOOD'] = f"Essentia: {mood_conf_str}"
-                tags_written.append(f"ESSENTIA_MOOD={mood_conf_str}")
+            if self.config.rb_write:
+                # Rekordbox-compatible path: merge a [MOOD: ...] marker
+                # into the WM/Comments field. Coexists with Mixed In Key.
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_text = ''
+                if 'WM/Comments' in audio:
+                    val = audio['WM/Comments']
+                    if val:
+                        existing_text = str(val[0])
+                new_text = merge_mood_into_comment(
+                    existing_text, mood_marker
+                )
+                audio['WM/Comments'] = new_text
+                tags_written.append(f"WM/Comments={new_text}")
+            else:
+                mood_str = '; '.join(results['formatted_moods'][:3])
+                audio['WM/Mood'] = mood_str
+                tags_written.append(f"WM/Mood={mood_str}")
+
+                if self.config.write_confidence_tags and results.get('moods'):
+                    mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
+                    mood_conf_str = ', '.join(mood_details)
+                    audio['ESSENTIA_MOOD'] = f"Essentia: {mood_conf_str}"
+                    tags_written.append(f"ESSENTIA_MOOD={mood_conf_str}")
         
         if tags_written:
             audio.save()
@@ -764,7 +843,7 @@ class TagWriter:
                     text=mood_str
                 ))
                 tags_written.append(f"COMM(mood)={mood_str}")
-
+        
         if tags_written:
             self.logger.log(f"     ✅ Written tags: {', '.join(tags_written)}", console=False)
     
@@ -799,15 +878,41 @@ class TagWriter:
                 self.logger.log("     ⏭️  Skipping genres (already has Genre tag)")
         
         if self.config.enable_moods and results.get('formatted_moods'):
-            mood_str = '; '.join(results['formatted_moods'][:3])
-            audio.tags['Mood'] = mood_str
-            tags_written.append(f"Mood={mood_str}")
-            
-            if self.config.write_confidence_tags and results.get('moods'):
-                mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
-                mood_conf_str = ', '.join(mood_details)
-                audio.tags['Essentia Mood'] = f"Essentia: {mood_conf_str}"
-                tags_written.append(f"Essentia Mood={mood_conf_str}")
+            if self.config.rb_write:
+                # Rekordbox-compatible path: merge a [MOOD: ...] marker
+                # into the standard APEv2 Comment field.
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_text = ''
+                if 'Comment' in audio.tags:
+                    val = audio.tags['Comment']
+                    if val:
+                        existing_text = (
+                            val[0] if isinstance(val, list) else str(val)
+                        )
+                new_text = merge_mood_into_comment(
+                    existing_text, mood_marker
+                )
+                audio.tags['Comment'] = new_text
+                tags_written.append(f"Comment={new_text}")
+            else:
+                mood_str = '; '.join(results['formatted_moods'][:3])
+                audio.tags['Mood'] = mood_str
+                tags_written.append(f"Mood={mood_str}")
+
+                if self.config.write_confidence_tags and results.get('moods'):
+                    mood_details = [f"{m['label']}: {m['confidence']:.2%}" for m in results['moods'][:3]]
+                    mood_conf_str = ', '.join(mood_details)
+                    audio.tags['Essentia Mood'] = f"Essentia: {mood_conf_str}"
+                    tags_written.append(f"Essentia Mood={mood_conf_str}")
         
         if tags_written:
             audio.save()
@@ -1669,7 +1774,8 @@ def configure_settings():
         print("     [MOOD: Happy; Energetic; Uplifting]")
         print("   This shows up in Rekordbox's Comments column and coexists")
         print("   with Mixed In Key's Energy/Key prefix.")
-        print("   Currently affects MP3 / AIFF / DSF only.")
+        print("   Supported on MP3 / AIFF / DSF / FLAC / OGG / Opus /")
+        print("   MP4 / M4A / WMA / APEv2 (WAV pending in a later step).")
         config.rb_write = get_yes_no(
             "Enable Rekordbox-compatible mood writing?", default=False
         )
@@ -1930,8 +2036,8 @@ Genre format styles:
             'Rekordbox-compatible mood writing: append mood as a '
             '[MOOD: ...] marker inside the standard Comments field so it is '
             'visible in Rekordbox. Coexists with Mixed In Key output. '
-            'Currently affects MP3/AIFF/DSF (ID3) only; other formats follow '
-            'in subsequent work.'
+            'Supports MP3/AIFF/DSF/FLAC/OGG/Opus/MP4/M4A/WMA/APEv2 '
+            '(WAV pending in a later step).'
         )
     )
 

--- a/tag_music.py
+++ b/tag_music.py
@@ -27,7 +27,7 @@ from mutagen.musepack import Musepack
 from mutagen.apev2 import APEv2
 from mutagen.asf import ASF
 
-from comment_merge import build_mood_marker, merge_mood_into_comment
+from comment_merge import build_mood_marker, merge_mood_into_comment, MOOD_MARKER_RE
 from riff_info import read_riff_info, update_riff_info
 
 # Supported audio file extensions
@@ -981,11 +981,16 @@ class TagWriter:
             self.logger.log(f"     ✅ Written tags: {', '.join(tags_written)}", console=False)
 
 
-def has_existing_tags(filepath, enable_genres, enable_moods):
-    """Quick check if file already has genre/mood tags (avoids expensive analysis)."""
+def has_existing_tags(filepath, enable_genres, enable_moods, rb_write=False):
+    """Quick check if file already has genre/mood tags (avoids expensive analysis).
+
+    When rb_write is True, mood detection searches for a [MOOD: ...] marker
+    inside each format's standard comment field instead of looking for the
+    dedicated MOOD / WM/Mood / Essentia Mood tags used in non-rb_write mode.
+    """
     try:
         audio = mutagen.File(filepath)
-        if audio is None or audio.tags is None:
+        if audio is None:
             return False
 
         ext = Path(filepath).suffix.lower()
@@ -993,40 +998,86 @@ def has_existing_tags(filepath, enable_genres, enable_moods):
         has_mood = False
 
         if ext in ('.flac', '.ogg', '.oga', '.opus'):
+            if audio.tags is None:
+                return False
             has_genre = 'GENRE' in audio
-            has_mood = 'MOOD' in audio
+            if rb_write:
+                comment_val = (
+                    audio['COMMENT'][0]
+                    if 'COMMENT' in audio and audio['COMMENT']
+                    else ''
+                )
+                has_mood = bool(MOOD_MARKER_RE.search(comment_val))
+            else:
+                has_mood = 'MOOD' in audio
+
         elif ext == '.wav':
-            # Genre is written to RIFF INFO IGNR; check that first.
-            # Mood marker detection in ICMT is deferred to step 6 of the plan.
             try:
                 info = read_riff_info(filepath)
                 has_genre = bool(info.get(b'IGNR', '').strip())
             except Exception:
+                info = {}
                 has_genre = False
+            # Fall back to ID3 TCON for files tagged before the RIFF INFO writer
             if not has_genre and audio.tags:
                 has_genre = bool(audio.tags.getall('TCON'))
-            has_mood = bool(audio.tags and any(
-                getattr(c, 'desc', '') == 'Essentia Mood'
-                for c in audio.tags.getall('COMM')
-            ))
+            if rb_write:
+                icmt = info.get(b'ICMT', '')
+                has_mood = bool(MOOD_MARKER_RE.search(icmt))
+            else:
+                has_mood = bool(audio.tags and any(
+                    getattr(c, 'desc', '') == 'Essentia Mood'
+                    for c in audio.tags.getall('COMM')
+                ))
+
         elif ext in ('.mp3', '.aiff', '.aif', '.dsf'):
+            if audio.tags is None:
+                return False
             tags = audio.tags
-            if tags:
-                has_genre = bool(tags.getall('TCON'))
+            has_genre = bool(tags.getall('TCON'))
+            if rb_write:
+                comm = tags.get('COMM::eng')
+                text = comm.text[0] if comm and comm.text else ''
+                has_mood = bool(MOOD_MARKER_RE.search(text))
+            else:
                 has_mood = any(
                     getattr(c, 'desc', '') == 'Essentia Mood'
                     for c in tags.getall('COMM')
                 )
+
         elif ext in ('.m4a', '.m4b', '.mp4', '.aac'):
+            if audio.tags is None:
+                return False
             has_genre = '\xa9gen' in audio
-            has_mood = '----:com.apple.iTunes:MOOD' in audio
+            if rb_write:
+                cmt = audio.tags.get('\xa9cmt')
+                text = str(cmt[0]) if cmt else ''
+                has_mood = bool(MOOD_MARKER_RE.search(text))
+            else:
+                has_mood = '----:com.apple.iTunes:MOOD' in audio
+
         elif ext == '.wma':
+            if audio.tags is None:
+                return False
             has_genre = 'WM/Genre' in audio
-            has_mood = 'WM/Mood' in audio
+            if rb_write:
+                wm_cmt = audio.get('WM/Comments')
+                text = str(wm_cmt[0]) if wm_cmt else ''
+                has_mood = bool(MOOD_MARKER_RE.search(text))
+            else:
+                has_mood = 'WM/Mood' in audio
+
         elif ext in ('.wv', '.ape', '.mpc', '.mp+'):
-            tags = audio.tags or {}
+            if audio.tags is None:
+                return False
+            tags = audio.tags
             has_genre = 'Genre' in tags
-            has_mood = 'Mood' in tags
+            if rb_write:
+                val = tags.get('Comment')
+                comment_val = val[0] if isinstance(val, list) else str(val) if val else ''
+                has_mood = bool(MOOD_MARKER_RE.search(comment_val))
+            else:
+                has_mood = 'Mood' in tags
 
         if enable_genres and enable_moods:
             return has_genre and has_mood
@@ -1095,7 +1146,7 @@ def _worker_process_file(args):
     try:
         # Early skip: check existing tags before expensive analysis
         if not config_dict['overwrite_existing'] and not config_dict['dry_run']:
-            if has_existing_tags(filepath, config_dict['enable_genres'], config_dict['enable_moods']):
+            if has_existing_tags(filepath, config_dict['enable_genres'], config_dict['enable_moods'], config_dict['rb_write']):
                 return {'filepath': filepath_str, 'status': 'skipped'}
 
         from essentia.standard import MonoLoader
@@ -1254,7 +1305,7 @@ def _scan_sequential(audio_files, root, analyzer, tag_writer, config, logger):
         
         # Early skip: avoid expensive analysis if tags already exist
         if not config.overwrite_existing and not config.dry_run:
-            if has_existing_tags(filepath, config.enable_genres, config.enable_moods):
+            if has_existing_tags(filepath, config.enable_genres, config.enable_moods, config.rb_write):
                 logger.log(f"[{i}/{total}] ⏭️  {relative_path} (already tagged)")
                 skipped += 1
                 logger.log("")
@@ -1294,6 +1345,7 @@ def _scan_parallel(audio_files, root, tag_writer, config, logger):
         'mood_threshold': config.mood_threshold,
         'genre_format': config.genre_format,
         'overwrite_existing': config.overwrite_existing,
+        'rb_write': config.rb_write,
         'dry_run': config.dry_run,
         'write_confidence_tags': config.write_confidence_tags,
         'verbose': config.verbose,

--- a/tag_music.py
+++ b/tag_music.py
@@ -701,7 +701,12 @@ class TagWriter:
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
                     confidence_str = ', '.join(genre_details)
-                    tags.delall('COMM::eng')
+                    # Delete only any prior 'Essentia Genre' confidence frame.
+                    # The previous key 'COMM::eng' targeted the *empty-desc*
+                    # English COMM, i.e. the user's main Comments field,
+                    # which would be wiped on every run. The correct hash key
+                    # for a description-tagged frame is 'COMM:<desc>:<lang>'.
+                    tags.delall('COMM:Essentia Genre:eng')
                     tags.add(COMM(
                         encoding=3,
                         lang='eng',

--- a/tag_music.py
+++ b/tag_music.py
@@ -28,6 +28,7 @@ from mutagen.apev2 import APEv2
 from mutagen.asf import ASF
 
 from comment_merge import build_mood_marker, merge_mood_into_comment
+from riff_info import read_riff_info, update_riff_info
 
 # Supported audio file extensions
 # Analysis: all formats Essentia MonoLoader can decode (via FFmpeg)
@@ -516,7 +517,9 @@ class TagWriter:
                 self._write_wma(filepath, results)
             elif file_ext in ('.aiff', '.aif'):
                 self._write_aiff(filepath, results)
-            elif file_ext in ('.wav', '.dsf'):
+            elif file_ext == '.wav':
+                self._write_wav(filepath, results)
+            elif file_ext == '.dsf':
                 self._write_id3_generic(filepath, results)
             elif file_ext in ('.wv', '.ape', '.mpc', '.mp+'):
                 self._write_apev2(filepath, results)
@@ -765,6 +768,65 @@ class TagWriter:
         self._write_id3_tags(audio.tags, results)
         audio.save()
     
+    def _write_wav(self, filepath, results):
+        """Write genre/mood to a WAV file via RIFF INFO chunks (Rekordbox-visible).
+
+        Rekordbox reads RIFF INFO, not ID3, from WAV files.  Genre goes to
+        IGNR; the rb_write mood marker goes to ICMT (merged with any existing
+        comment).  For non-rb_write mode the existing ID3-in-WAV path is also
+        called so that foobar2000 / Mp3tag users still see mood data.
+        """
+        try:
+            existing_info = read_riff_info(filepath)
+        except ValueError as exc:
+            self.logger.log(f"     ⚠️  RIFF INFO read error: {exc}")
+            return
+
+        riff_updates = {}
+        tags_written = []
+
+        if self.config.enable_genres and results.get('formatted_genres'):
+            has_existing = bool(existing_info.get(b'IGNR', '').strip())
+            if self.config.overwrite_existing or not has_existing:
+                genre_str = '; '.join(results['formatted_genres'])
+                riff_updates[b'IGNR'] = genre_str
+                tags_written.append(f'IGNR={genre_str}')
+            else:
+                self.logger.log("     ⏭️  Skipping genres (already has IGNR tag)")
+
+        if self.config.enable_moods and results.get('formatted_moods'):
+            if self.config.rb_write:
+                top_moods = results['formatted_moods'][:3]
+                if (self.config.write_confidence_tags
+                        and results.get('moods')):
+                    confidences = [
+                        m['confidence'] for m in results['moods'][:3]
+                    ]
+                    mood_marker = build_mood_marker(top_moods, confidences)
+                else:
+                    mood_marker = build_mood_marker(top_moods)
+
+                existing_icmt = existing_info.get(b'ICMT', '')
+                new_icmt = merge_mood_into_comment(existing_icmt, mood_marker)
+                riff_updates[b'ICMT'] = new_icmt
+                tags_written.append(f'ICMT={new_icmt}')
+
+        if riff_updates:
+            try:
+                update_riff_info(filepath, riff_updates)
+            except Exception as exc:
+                self.logger.log(f"     ⚠️  RIFF INFO write failed: {exc}")
+                return
+            self.logger.log(
+                f"     ✅ Written RIFF INFO: {', '.join(tags_written)}",
+                console=False,
+            )
+
+        # For non-rb_write mode also write ID3 tags inside the WAV container
+        # so non-Rekordbox players (foobar2000, Mp3tag) can read mood/genre.
+        if not self.config.rb_write:
+            self._write_id3_generic(filepath, results)
+
     def _write_id3_tags(self, tags, results):
         """Shared ID3v2 tag writer used by MP3, AIFF, WAV, DSF"""
         tags_written = []
@@ -933,7 +995,21 @@ def has_existing_tags(filepath, enable_genres, enable_moods):
         if ext in ('.flac', '.ogg', '.oga', '.opus'):
             has_genre = 'GENRE' in audio
             has_mood = 'MOOD' in audio
-        elif ext in ('.mp3', '.aiff', '.aif', '.wav', '.dsf'):
+        elif ext == '.wav':
+            # Genre is written to RIFF INFO IGNR; check that first.
+            # Mood marker detection in ICMT is deferred to step 6 of the plan.
+            try:
+                info = read_riff_info(filepath)
+                has_genre = bool(info.get(b'IGNR', '').strip())
+            except Exception:
+                has_genre = False
+            if not has_genre and audio.tags:
+                has_genre = bool(audio.tags.getall('TCON'))
+            has_mood = bool(audio.tags and any(
+                getattr(c, 'desc', '') == 'Essentia Mood'
+                for c in audio.tags.getall('COMM')
+            ))
+        elif ext in ('.mp3', '.aiff', '.aif', '.dsf'):
             tags = audio.tags
             if tags:
                 has_genre = bool(tags.getall('TCON'))
@@ -1774,8 +1850,8 @@ def configure_settings():
         print("     [MOOD: Happy; Energetic; Uplifting]")
         print("   This shows up in Rekordbox's Comments column and coexists")
         print("   with Mixed In Key's Energy/Key prefix.")
-        print("   Supported on MP3 / AIFF / DSF / FLAC / OGG / Opus /")
-        print("   MP4 / M4A / WMA / APEv2 (WAV pending in a later step).")
+        print("   Supported on MP3 / AIFF / DSF / WAV / FLAC / OGG / Opus /")
+        print("   MP4 / M4A / WMA / APEv2.")
         config.rb_write = get_yes_no(
             "Enable Rekordbox-compatible mood writing?", default=False
         )
@@ -2036,8 +2112,7 @@ Genre format styles:
             'Rekordbox-compatible mood writing: append mood as a '
             '[MOOD: ...] marker inside the standard Comments field so it is '
             'visible in Rekordbox. Coexists with Mixed In Key output. '
-            'Supports MP3/AIFF/DSF/FLAC/OGG/Opus/MP4/M4A/WMA/APEv2 '
-            '(WAV pending in a later step).'
+            'Supports MP3/AIFF/DSF/WAV/FLAC/OGG/Opus/MP4/M4A/WMA/APEv2.'
         )
     )
 

--- a/test_comment_merge.py
+++ b/test_comment_merge.py
@@ -1,0 +1,234 @@
+"""
+Tests for comment_merge.
+
+Run from the project root:
+    python -m unittest test_comment_merge -v
+"""
+
+import unittest
+
+from comment_merge import (
+    MOOD_MARKER_RE,
+    build_mood_marker,
+    merge_mood_into_comment,
+)
+
+
+class BuildMoodMarkerTests(unittest.TestCase):
+    """build_mood_marker formats the bracketed marker string."""
+
+    def test_empty_items_returns_empty_string(self):
+        self.assertEqual(build_mood_marker([]), '')
+
+    def test_single_item(self):
+        self.assertEqual(build_mood_marker(['Happy']), '[MOOD: Happy]')
+
+    def test_multiple_items_semicolon_separated(self):
+        self.assertEqual(
+            build_mood_marker(['Happy', 'Energetic', 'Uplifting']),
+            '[MOOD: Happy; Energetic; Uplifting]',
+        )
+
+    def test_does_not_transform_label_casing(self):
+        # The function takes pre-formatted labels and should pass them
+        # through unchanged.
+        self.assertEqual(
+            build_mood_marker(['happy', 'ENERGETIC']),
+            '[MOOD: happy; ENERGETIC]',
+        )
+
+    def test_with_confidences_appends_percentages(self):
+        result = build_mood_marker(
+            ['Happy', 'Energetic'],
+            confidences=[0.87, 0.72],
+        )
+        self.assertEqual(result, '[MOOD: Happy 87%; Energetic 72%]')
+
+    def test_confidence_rounding_half_up(self):
+        # 0.875 -> 88, 0.874 -> 87 (banker's rounding may apply in Python --
+        # round() uses banker's rounding, so 0.875 actually rounds to nearest
+        # even. We assert the Python-standard behaviour rather than half-up.)
+        result = build_mood_marker(
+            ['A', 'B', 'C'],
+            confidences=[0.874, 0.876, 1.0],
+        )
+        self.assertEqual(result, '[MOOD: A 87%; B 88%; C 100%]')
+
+    def test_confidence_zero_and_one_boundaries(self):
+        result = build_mood_marker(['Low', 'High'], confidences=[0.0, 1.0])
+        self.assertEqual(result, '[MOOD: Low 0%; High 100%]')
+
+    def test_mismatched_lengths_raises(self):
+        with self.assertRaises(ValueError):
+            build_mood_marker(['A', 'B'], confidences=[0.5])
+
+    def test_empty_items_with_empty_confidences_returns_empty(self):
+        # The empty-items short-circuit fires before length validation, which
+        # is the expected behaviour: no items means no marker.
+        self.assertEqual(build_mood_marker([], confidences=[]), '')
+
+
+class MergeMoodIntoCommentTests(unittest.TestCase):
+    """merge_mood_into_comment handles all the cases the tagger will hit."""
+
+    MARKER = '[MOOD: Happy; Energetic]'
+    OTHER_MARKER = '[MOOD: Sad; Mellow]'
+
+    # --- empty / None inputs -------------------------------------------------
+
+    def test_none_existing_comment_returns_just_marker(self):
+        self.assertEqual(
+            merge_mood_into_comment(None, self.MARKER),
+            self.MARKER,
+        )
+
+    def test_empty_existing_comment_returns_just_marker(self):
+        self.assertEqual(
+            merge_mood_into_comment('', self.MARKER),
+            self.MARKER,
+        )
+
+    def test_whitespace_only_existing_comment_returns_just_marker(self):
+        self.assertEqual(
+            merge_mood_into_comment('   \t  ', self.MARKER),
+            self.MARKER,
+        )
+
+    # --- appending to existing content --------------------------------------
+
+    def test_existing_comment_no_prior_marker_appends(self):
+        self.assertEqual(
+            merge_mood_into_comment('Killer drop at 1:30', self.MARKER),
+            'Killer drop at 1:30 [MOOD: Happy; Energetic]',
+        )
+
+    def test_mik_prefix_only_is_preserved(self):
+        # MIK writes 'Energy X - Yk - ' with a trailing dash and space when
+        # there's no other comment text.
+        result = merge_mood_into_comment('Energy 7 - 8A - ', self.MARKER)
+        self.assertEqual(
+            result,
+            'Energy 7 - 8A - [MOOD: Happy; Energetic]',
+        )
+
+    def test_mik_prefix_plus_user_comment_is_preserved(self):
+        result = merge_mood_into_comment(
+            'Energy 7 - 8A - Killer drop at 1:30',
+            self.MARKER,
+        )
+        self.assertEqual(
+            result,
+            'Energy 7 - 8A - Killer drop at 1:30 [MOOD: Happy; Energetic]',
+        )
+
+    # --- replacing prior markers -------------------------------------------
+
+    def test_prior_marker_is_replaced_no_duplication(self):
+        existing = 'Killer drop [MOOD: Sad; Mellow]'
+        result = merge_mood_into_comment(existing, self.MARKER)
+        self.assertEqual(result, 'Killer drop [MOOD: Happy; Energetic]')
+
+    def test_idempotent_under_repeat(self):
+        # Running the merger twice with the same marker must be a no-op
+        # after the first run -- this is critical for re-runs of the tagger.
+        first = merge_mood_into_comment('Existing comment', self.MARKER)
+        second = merge_mood_into_comment(first, self.MARKER)
+        self.assertEqual(first, second)
+
+    def test_idempotent_with_mik_prefix(self):
+        existing = 'Energy 7 - 8A - Killer drop'
+        first = merge_mood_into_comment(existing, self.MARKER)
+        second = merge_mood_into_comment(first, self.MARKER)
+        self.assertEqual(first, second)
+        # And the MIK prefix is still intact.
+        self.assertTrue(second.startswith('Energy 7 - 8A - '))
+
+    def test_marker_only_existing_returns_just_new_marker(self):
+        result = merge_mood_into_comment(self.OTHER_MARKER, self.MARKER)
+        self.assertEqual(result, self.MARKER)
+
+    def test_marker_at_start_of_existing_comment(self):
+        result = merge_mood_into_comment(
+            '[MOOD: Sad] Killer drop',
+            self.MARKER,
+        )
+        self.assertEqual(result, 'Killer drop [MOOD: Happy; Energetic]')
+
+    def test_marker_in_middle_of_existing_comment(self):
+        result = merge_mood_into_comment(
+            'pre [MOOD: Sad] post',
+            self.MARKER,
+        )
+        self.assertEqual(result, 'pre post [MOOD: Happy; Energetic]')
+
+    def test_multiple_prior_markers_are_all_stripped(self):
+        # Defensive: if some earlier bug or external tool produced multiple
+        # markers, we should still recover cleanly.
+        existing = '[MOOD: Old1] middle [MOOD: Old2] tail'
+        result = merge_mood_into_comment(existing, self.MARKER)
+        self.assertEqual(result, 'middle tail [MOOD: Happy; Energetic]')
+
+    def test_case_insensitive_marker_stripping(self):
+        # Lowercase or mixed-case prior markers should be cleaned up too.
+        result = merge_mood_into_comment(
+            'note [mood: stale]',
+            self.MARKER,
+        )
+        self.assertEqual(result, 'note [MOOD: Happy; Energetic]')
+
+    # --- empty marker (strip-only mode) -------------------------------------
+
+    def test_empty_marker_strips_existing_marker(self):
+        result = merge_mood_into_comment('comment [MOOD: Sad]', '')
+        self.assertEqual(result, 'comment')
+
+    def test_empty_marker_with_no_existing_marker(self):
+        result = merge_mood_into_comment('comment', '')
+        self.assertEqual(result, 'comment')
+
+    def test_empty_marker_and_empty_existing(self):
+        self.assertEqual(merge_mood_into_comment(None, ''), '')
+        self.assertEqual(merge_mood_into_comment('', ''), '')
+
+    # --- whitespace handling ------------------------------------------------
+
+    def test_no_double_spaces_after_strip(self):
+        # If the marker had spaces on both sides and we strip it, we mustn't
+        # leave a double space behind.
+        existing = 'pre  [MOOD: Sad]  post'
+        result = merge_mood_into_comment(existing, self.MARKER)
+        self.assertEqual(result, 'pre post [MOOD: Happy; Energetic]')
+
+    def test_adjacent_markers_collapse_cleanly(self):
+        # Pathological input but should still produce sane output.
+        existing = '[MOOD: A][MOOD: B]'
+        result = merge_mood_into_comment(existing, self.MARKER)
+        self.assertEqual(result, self.MARKER)
+
+
+class MoodMarkerRegexTests(unittest.TestCase):
+    """Sanity checks on the regex itself."""
+
+    def test_matches_basic_marker(self):
+        self.assertIsNotNone(MOOD_MARKER_RE.search('[MOOD: x]'))
+
+    def test_matches_with_semicolon_list(self):
+        self.assertIsNotNone(
+            MOOD_MARKER_RE.search('foo [MOOD: a; b; c] bar')
+        )
+
+    def test_matches_with_percentages(self):
+        self.assertIsNotNone(
+            MOOD_MARKER_RE.search('[MOOD: Happy 87%; Sad 12%]')
+        )
+
+    def test_does_not_match_bare_word(self):
+        self.assertIsNone(MOOD_MARKER_RE.search('mood happy'))
+
+    def test_does_not_match_unclosed_marker(self):
+        # No closing bracket -- shouldn't eat the rest of the comment.
+        self.assertIsNone(MOOD_MARKER_RE.search('[MOOD: x'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_riff_info.py
+++ b/test_riff_info.py
@@ -296,6 +296,42 @@ class TestUpdateRiffInfo(unittest.TestCase):
         with self.assertRaises(ValueError):
             update_riff_info(tmp.name, {b'ICMT': 'x'})
 
+    def test_appends_pad_byte_when_existing_data_is_odd_length(self):
+        """A WAV whose last chunk omitted its pad byte (file length odd) must
+        get a pad byte inserted before the appended LIST INFO so that
+        downstream chunk-walkers don't land at a misaligned offset."""
+        fmt_body = _fmt_chunk()
+        fmt_chunk = b'fmt ' + struct.pack('<I', len(fmt_body)) + fmt_body
+        odd_samples = b'\x10\x20\x30'   # 3 bytes (odd) — no trailing pad
+        data_chunk = b'data' + struct.pack('<I', len(odd_samples)) + odd_samples
+        body = b'WAVE' + fmt_chunk + data_chunk
+        odd_wav = b'RIFF' + struct.pack('<I', len(body)) + body
+        # Sanity: setup must actually produce an odd-length file
+        self.assertEqual(len(odd_wav) % 2, 1)
+
+        path = self._write_temp(odd_wav)
+        update_riff_info(path, {b'ICMT': 'rb-mood marker'})
+
+        new_data = Path(path).read_bytes()
+
+        # File is now even-aligned
+        self.assertEqual(len(new_data) % 2, 0)
+
+        # RIFF size header matches new file length minus 8
+        stored_size = struct.unpack_from('<I', new_data, 4)[0]
+        self.assertEqual(stored_size, len(new_data) - 8)
+
+        # The new ICMT round-trips
+        self.assertEqual(read_riff_info(path)[b'ICMT'], 'rb-mood marker')
+
+        # Pre-existing chunks are still intact
+        self.assertIn(b'fmt ', new_data)
+        self.assertIn(b'data', new_data)
+        self.assertIn(odd_samples, new_data)
+
+        # The full structural validator must accept the rewritten file
+        _validate_wav_structure(new_data)
+
     def test_mood_marker_merge_via_comment_merge(self):
         """Integration: merging a [MOOD:] marker into an existing ICMT value."""
         from comment_merge import build_mood_marker, merge_mood_into_comment

--- a/test_riff_info.py
+++ b/test_riff_info.py
@@ -13,6 +13,7 @@ from riff_info import (
     _encode_subchunk,
     _locate_list_info,
     _parse_riff_info,
+    _validate_wav_structure,
     read_riff_info,
     update_riff_info,
 )
@@ -318,6 +319,120 @@ class TestUpdateRiffInfo(unittest.TestCase):
             update_riff_info(path, {b'ICMT': new_val})
         result = read_riff_info(path)[b'ICMT']
         self.assertEqual(result.count('[MOOD:'), 1)
+
+
+# ---------------------------------------------------------------------------
+# _validate_wav_structure
+# ---------------------------------------------------------------------------
+
+def _make_chunk(fourcc, body):
+    """Build a single raw RIFF chunk (header + body, no pad)."""
+    return fourcc + struct.pack('<I', len(body)) + body
+
+
+def _make_chunk_padded(fourcc, body):
+    """Build a RIFF chunk with padding byte when body length is odd."""
+    chunk = _make_chunk(fourcc, body)
+    if len(body) % 2 != 0:
+        chunk += b'\x00'
+    return chunk
+
+
+class TestValidateWavStructure(unittest.TestCase):
+
+    def test_valid_wav_passes(self):
+        # A well-formed minimal WAV should not raise.
+        _validate_wav_structure(_make_wav())
+
+    def test_valid_wav_with_list_info_passes(self):
+        _validate_wav_structure(_make_wav(_make_list_info(ICMT='ok')))
+
+    def test_non_wav_raises(self):
+        with self.assertRaises(ValueError):
+            _validate_wav_structure(b'this is not a wav')
+
+    def test_oversized_chunk_raises(self):
+        # Build a chunk whose declared size runs past end of file.
+        bad_chunk = b'data' + struct.pack('<I', 9999) + b'\x00' * 4
+        wav = _make_wav(bad_chunk)
+        with self.assertRaises(ValueError) as ctx:
+            _validate_wav_structure(wav)
+        self.assertIn('data', str(ctx.exception))
+
+    def test_error_names_the_bad_chunk(self):
+        bad_chunk = b'bext' + struct.pack('<I', 9999) + b'\x00' * 4
+        wav = _make_wav(bad_chunk)
+        with self.assertRaises(ValueError) as ctx:
+            _validate_wav_structure(wav)
+        self.assertIn('bext', str(ctx.exception))
+
+    def test_bext_chunk_passes_when_well_formed(self):
+        # Pro Tools broadcast WAV extension chunk; 602 bytes minimum.
+        bext_body = b'\x00' * 602
+        bext = _make_chunk_padded(b'bext', bext_body)
+        _validate_wav_structure(_make_wav(bext))
+
+    def test_junk_chunk_passes_when_well_formed(self):
+        # Rekordbox alignment padding chunk.
+        junk = _make_chunk_padded(b'JUNK', b'\x00' * 28)
+        _validate_wav_structure(_make_wav(junk))
+
+    def test_lowercase_junk_chunk_passes(self):
+        junk = _make_chunk_padded(b'junk', b'\x00' * 16)
+        _validate_wav_structure(_make_wav(junk))
+
+    def test_multiple_valid_chunks_pass(self):
+        bext = _make_chunk_padded(b'bext', b'\x00' * 602)
+        junk = _make_chunk_padded(b'JUNK', b'\x00' * 28)
+        list_info = _make_list_info(ICMT='test', IGNR='Rock')
+        _validate_wav_structure(_make_wav(bext, junk, list_info))
+
+    def test_zero_size_chunk_passes(self):
+        # A chunk with size 0 is unusual but valid.
+        empty_chunk = _make_chunk(b'PAD ', b'')
+        _validate_wav_structure(_make_wav(empty_chunk))
+
+    def test_label_appears_in_error_message(self):
+        bad_chunk = b'data' + struct.pack('<I', 9999) + b'\x00' * 4
+        wav = _make_wav(bad_chunk)
+        with self.assertRaises(ValueError) as ctx:
+            _validate_wav_structure(wav, label='my_file.wav')
+        self.assertIn('my_file.wav', str(ctx.exception))
+
+
+class TestUpdateRiffInfoValidation(unittest.TestCase):
+    """Verify update_riff_info refuses to write when the WAV is malformed."""
+
+    def _write_temp(self, wav_bytes):
+        tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        tmp.write(wav_bytes)
+        tmp.close()
+        return tmp.name
+
+    def test_malformed_wav_raises_before_write(self):
+        # Build a WAV with a chunk whose size runs past EOF.
+        bad_chunk = b'data' + struct.pack('<I', 9999) + b'\x00' * 4
+        path = self._write_temp(_make_wav(bad_chunk))
+        original_bytes = Path(path).read_bytes()
+
+        with self.assertRaises(ValueError):
+            update_riff_info(path, {b'ICMT': 'should not be written'})
+
+        # File must be byte-identical to what it was before the call.
+        self.assertEqual(Path(path).read_bytes(), original_bytes)
+
+    def test_well_formed_wav_with_extra_chunks_writes_correctly(self):
+        # bext + JUNK + existing LIST INFO — all well-formed.
+        bext = _make_chunk_padded(b'bext', b'\x00' * 602)
+        junk = _make_chunk_padded(b'JUNK', b'\x00' * 28)
+        list_info = _make_list_info(IGNR='Jazz')
+        path = self._write_temp(_make_wav(bext, junk, list_info))
+
+        update_riff_info(path, {b'ICMT': 'added'})
+
+        result = read_riff_info(path)
+        self.assertEqual(result[b'IGNR'], 'Jazz')
+        self.assertEqual(result[b'ICMT'], 'added')
 
 
 if __name__ == '__main__':

--- a/test_riff_info.py
+++ b/test_riff_info.py
@@ -1,0 +1,324 @@
+"""Unit tests for riff_info.py.
+
+All tests use in-memory synthesised WAV bytes where possible; real-file
+tests use tempfile so no permanent files are created.
+"""
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from riff_info import (
+    _build_list_info,
+    _encode_subchunk,
+    _locate_list_info,
+    _parse_riff_info,
+    read_riff_info,
+    update_riff_info,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic WAV data
+# ---------------------------------------------------------------------------
+
+def _fmt_chunk():
+    """Minimal 16-byte PCM fmt sub-chunk body."""
+    # audio_format=1 (PCM), channels=1, sample_rate=44100,
+    # byte_rate=88200, block_align=2, bits=16
+    return struct.pack('<HHIIHH', 1, 1, 44100, 88200, 2, 16)
+
+
+def _make_wav(*extra_chunks):
+    """Return a minimal RIFF WAVE file as bytes.
+
+    extra_chunks: sequence of raw bytes (complete chunks, header included)
+    that will be appended after the fmt  and data chunks.
+    """
+    fmt_body = _fmt_chunk()
+    fmt_chunk = b'fmt ' + struct.pack('<I', len(fmt_body)) + fmt_body
+
+    samples = b'\x00\x00'       # one silent 16-bit sample
+    data_chunk = b'data' + struct.pack('<I', len(samples)) + samples
+
+    body = b'WAVE' + fmt_chunk + data_chunk
+    for chunk in extra_chunks:
+        body += chunk
+
+    return b'RIFF' + struct.pack('<I', len(body)) + body
+
+
+def _make_list_info(**kwargs):
+    """Return a LIST/INFO chunk bytes with the given FOURCC=text items."""
+    info_dict = {k.encode('ascii'): v for k, v in kwargs.items()}
+    return _build_list_info(info_dict)
+
+
+# ---------------------------------------------------------------------------
+# _encode_subchunk
+# ---------------------------------------------------------------------------
+
+class TestEncodeSubchunk(unittest.TestCase):
+
+    def test_even_length(self):
+        # "Hi" + null = 3 bytes (odd) → padded to 4 bytes on disk; size=3
+        chunk = _encode_subchunk(b'ICMT', 'Hi')
+        fourcc = chunk[:4]
+        size = struct.unpack_from('<I', chunk, 4)[0]
+        value = chunk[8:8 + size]
+        self.assertEqual(fourcc, b'ICMT')
+        self.assertEqual(value, b'Hi\x00')
+        # total on-disk length must be even
+        self.assertEqual(len(chunk) % 2, 0)
+
+    def test_odd_length_no_pad_needed(self):
+        # "Yes" + null = 4 bytes (even) → no extra pad; size=4
+        chunk = _encode_subchunk(b'ICMT', 'Yes')
+        size = struct.unpack_from('<I', chunk, 4)[0]
+        self.assertEqual(size, 4)
+        self.assertEqual(len(chunk), 12)   # 4+4+4
+
+    def test_empty_string(self):
+        chunk = _encode_subchunk(b'ICMT', '')
+        size = struct.unpack_from('<I', chunk, 4)[0]
+        # just a null byte; size=1 (odd) → padded to 2 on disk
+        self.assertEqual(size, 1)
+        self.assertEqual(len(chunk) % 2, 0)
+
+    def test_bytes_key(self):
+        chunk = _encode_subchunk(b'IGNR', 'Rock')
+        self.assertEqual(chunk[:4], b'IGNR')
+
+
+# ---------------------------------------------------------------------------
+# _parse_riff_info
+# ---------------------------------------------------------------------------
+
+class TestParseRiffInfo(unittest.TestCase):
+
+    def test_no_list_info_returns_empty(self):
+        wav = _make_wav()
+        self.assertEqual(_parse_riff_info(wav), {})
+
+    def test_single_key(self):
+        list_chunk = _make_list_info(ICMT='Happy vibes')
+        wav = _make_wav(list_chunk)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result.get(b'ICMT'), 'Happy vibes')
+
+    def test_multiple_keys(self):
+        list_chunk = _make_list_info(ICMT='A comment', IGNR='Electronic')
+        wav = _make_wav(list_chunk)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result[b'ICMT'], 'A comment')
+        self.assertEqual(result[b'IGNR'], 'Electronic')
+
+    def test_odd_length_value_parses_correctly(self):
+        # "Hi" is 2 chars → null-terminated is 3 bytes (odd)
+        list_chunk = _make_list_info(ICMT='Hi')
+        wav = _make_wav(list_chunk)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result[b'ICMT'], 'Hi')
+
+    def test_value_with_embedded_null_trimmed(self):
+        # Manually craft a subchunk with an embedded null
+        value = b'Foo\x00Bar\x00'
+        sub = b'ICMT' + struct.pack('<I', len(value)) + value
+        info_body = b'INFO' + sub
+        list_chunk = b'LIST' + struct.pack('<I', len(info_body)) + info_body
+        wav = _make_wav(list_chunk)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result[b'ICMT'], 'Foo')
+
+    def test_chunk_after_list_info_not_required(self):
+        # LIST INFO at the very end of file should still parse
+        list_chunk = _make_list_info(ICMT='end')
+        wav = _make_wav(list_chunk)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result[b'ICMT'], 'end')
+
+    def test_non_info_list_chunk_ignored(self):
+        # A LIST chunk with type 'adtl' should not be mistaken for LIST INFO
+        adtl_body = b'adtl' + b'\x00' * 4
+        adtl_chunk = b'LIST' + struct.pack('<I', len(adtl_body)) + adtl_body
+        list_info = _make_list_info(ICMT='found me')
+        wav = _make_wav(adtl_chunk, list_info)
+        result = _parse_riff_info(wav)
+        self.assertEqual(result[b'ICMT'], 'found me')
+
+
+# ---------------------------------------------------------------------------
+# _locate_list_info
+# ---------------------------------------------------------------------------
+
+class TestLocateListInfo(unittest.TestCase):
+
+    def test_returns_none_when_absent(self):
+        wav = _make_wav()
+        self.assertIsNone(_locate_list_info(wav))
+
+    def test_returns_offsets_when_present(self):
+        list_chunk = _make_list_info(ICMT='x')
+        wav = _make_wav(list_chunk)
+        loc = _locate_list_info(wav)
+        self.assertIsNotNone(loc)
+        start, end = loc
+        # The LIST/INFO chunk starts after fmt  and data chunks
+        self.assertGreater(start, 12)
+        self.assertGreater(end, start)
+        # The bytes at start should be LIST
+        self.assertEqual(wav[start:start + 4], b'LIST')
+
+
+# ---------------------------------------------------------------------------
+# read_riff_info
+# ---------------------------------------------------------------------------
+
+class TestReadRiffInfo(unittest.TestCase):
+
+    def _write_temp(self, wav_bytes):
+        tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        tmp.write(wav_bytes)
+        tmp.close()
+        return tmp.name
+
+    def test_read_no_info(self):
+        path = self._write_temp(_make_wav())
+        self.assertEqual(read_riff_info(path), {})
+
+    def test_read_with_info(self):
+        path = self._write_temp(_make_wav(_make_list_info(ICMT='Hello')))
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'Hello')
+
+    def test_raises_for_non_wav(self):
+        tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        tmp.write(b'this is not a wav file at all')
+        tmp.close()
+        with self.assertRaises(ValueError):
+            read_riff_info(tmp.name)
+
+
+# ---------------------------------------------------------------------------
+# update_riff_info
+# ---------------------------------------------------------------------------
+
+class TestUpdateRiffInfo(unittest.TestCase):
+
+    def _write_temp(self, wav_bytes):
+        tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        tmp.write(wav_bytes)
+        tmp.close()
+        return tmp.name
+
+    def test_insert_into_file_with_no_list_info(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {b'ICMT': 'mood here'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'mood here')
+
+    def test_update_existing_key(self):
+        path = self._write_temp(_make_wav(_make_list_info(ICMT='old')))
+        update_riff_info(path, {b'ICMT': 'new'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'new')
+
+    def test_preserves_unmodified_keys(self):
+        path = self._write_temp(_make_wav(_make_list_info(ICMT='comment', IGNR='Jazz')))
+        update_riff_info(path, {b'ICMT': 'updated comment'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'updated comment')
+        self.assertEqual(result[b'IGNR'], 'Jazz')
+
+    def test_adds_new_key_alongside_existing(self):
+        path = self._write_temp(_make_wav(_make_list_info(IGNR='Rock')))
+        update_riff_info(path, {b'ICMT': 'new comment'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'IGNR'], 'Rock')
+        self.assertEqual(result[b'ICMT'], 'new comment')
+
+    def test_str_key_accepted(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {'ICMT': 'str key works'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'str key works')
+
+    def test_idempotent(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {b'ICMT': 'same'})
+        update_riff_info(path, {b'ICMT': 'same'})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'same')
+        # ICMT should not have been duplicated
+        data = Path(path).read_bytes()
+        self.assertEqual(data.count(b'ICMT'), 1)
+
+    def test_riff_size_header_is_correct_after_insert(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {b'ICMT': 'test'})
+        data = Path(path).read_bytes()
+        stored_size = struct.unpack_from('<I', data, 4)[0]
+        self.assertEqual(stored_size, len(data) - 8)
+
+    def test_riff_size_header_is_correct_after_update(self):
+        path = self._write_temp(_make_wav(_make_list_info(ICMT='short')))
+        update_riff_info(path, {b'ICMT': 'a much longer comment than before'})
+        data = Path(path).read_bytes()
+        stored_size = struct.unpack_from('<I', data, 4)[0]
+        self.assertEqual(stored_size, len(data) - 8)
+
+    def test_fmt_chunk_preserved(self):
+        # The fmt  chunk must survive a write
+        wav = _make_wav()
+        path = self._write_temp(wav)
+        update_riff_info(path, {b'ICMT': 'check'})
+        data = Path(path).read_bytes()
+        self.assertIn(b'fmt ', data)
+        self.assertIn(b'data', data)
+
+    def test_odd_value_round_trips(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {b'ICMT': 'Hi'})   # 2 chars → odd null-terminated
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], 'Hi')
+
+    def test_empty_value_round_trips(self):
+        path = self._write_temp(_make_wav())
+        update_riff_info(path, {b'ICMT': ''})
+        result = read_riff_info(path)
+        self.assertEqual(result[b'ICMT'], '')
+
+    def test_raises_for_non_wav(self):
+        tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+        tmp.write(b'definitely not a wav')
+        tmp.close()
+        with self.assertRaises(ValueError):
+            update_riff_info(tmp.name, {b'ICMT': 'x'})
+
+    def test_mood_marker_merge_via_comment_merge(self):
+        """Integration: merging a [MOOD:] marker into an existing ICMT value."""
+        from comment_merge import build_mood_marker, merge_mood_into_comment
+        path = self._write_temp(_make_wav(_make_list_info(ICMT='Energy 7 - 8A')))
+        existing = read_riff_info(path)[b'ICMT']
+        marker = build_mood_marker(['Happy', 'Energetic'])
+        new_val = merge_mood_into_comment(existing, marker)
+        update_riff_info(path, {b'ICMT': new_val})
+        result = read_riff_info(path)[b'ICMT']
+        self.assertIn('[MOOD:', result)
+        self.assertIn('Energy 7 - 8A', result)
+
+    def test_mood_marker_idempotent_via_comment_merge(self):
+        """Re-running the merge should not accumulate markers."""
+        from comment_merge import build_mood_marker, merge_mood_into_comment
+        path = self._write_temp(_make_wav())
+        marker = build_mood_marker(['Happy'])
+        for _ in range(3):
+            existing = read_riff_info(path).get(b'ICMT', '')
+            new_val = merge_mood_into_comment(existing, marker)
+            update_riff_info(path, {b'ICMT': new_val})
+        result = read_riff_info(path)[b'ICMT']
+        self.assertEqual(result.count('[MOOD:'), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hey there,

This is really just some trash vibe coding, but I wanted to use your great idea with Rekordbox and the tags as set-up don't necessarily appear properly for mood (I think).

The workflow I was about to do manually for all my music is:
1) Assign genre 
2) Assign mood in the comments 
You can then create 'smart' playlists based on string filters (e.g. a playlist of 'genre _contains_ techno' and 'mood _contains_ dark')

Unfortunately I have about 3000 tracks in my library and after about 70 my soul began to die.  I found your post on Reddit, and seemed exactly what I needed, but the challenge is having the metadata in a format that Rekordbox can easily read. The current approach of an ESSENTIA_GENRE comment field didn't work super well for this. 

I've made the following changes, largely with Claude (I'm primarily a mechanical engineer, not a software one, so please forgive my laziness). The main differences are:

1) Add --rb-write flag, which toggles changes from your original version to the modified Rekordbox formats
2) For most file types, we add a [MOOD: XX; XX;XX] format string to the comments. This is detected and rewritten using regex. Mixed in Key does a similar thing for energy levels. 
3) For WAV, the comments are a bit harder to embed in the binary but the same thing is now achieved. I added some checks and tests to make sure that the binary data of the WAV isn't corrupted. 
4) There are some general tests of the functionality as auxiliary py scripts also. 
5) Also included are one or more small changes around the overwrite functionality, as if using the RB format we need to change where the overwriting logic is/isn't performed.

Let me know your thoughts. Not sure if this really aligns with your use case for the code, but I'll almost definitely keep this fork if not. I'd also be really interested to look into 1) whether there's a more useful 'mood' library and 2) If there's a way to integrate both 'danceability' (easy) and some combined energy level metric (maybe a bit harder) as optional flags. 

Happy to discuss more etc in the comments to this. Setting up as a draft PR for now to enable this!

Pete


