### PR TITLE
Add genre split format

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ __pycache__/
 .github/
 .vscode/
 .idea/
-essentia_models/
 test/
 tmp/
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN uv pip install --system --no-cache essentia-tensorflow
 COPY requirements.txt .
 RUN uv pip install --system --no-cache mutagen numpy
 
-# Download ML models at build time
+# Copy local models into image if available; download any that are missing (-nc skips existing files)
+COPY essentia_models/ /app/essentia_models/
 COPY download_models.sh .
 ENV HOME=/app
 RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -31,7 +31,8 @@ RUN uv pip install --system --no-cache essentia-tensorflow
 COPY requirements.txt .
 RUN uv pip install --system --no-cache mutagen numpy
 
-# Download ML models at build time
+# Copy local models into image if available; download any that are missing (-nc skips existing files)
+COPY essentia_models/ /app/essentia_models/
 COPY download_models.sh .
 ENV HOME=/app
 RUN sed -i 's/\r$//' download_models.sh && bash download_models.sh

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ You'll be prompted for:
 **Recommendation:** Run in dry-run mode first to preview results!
 
 ---
-
 ## 🐳 Docker
 
 ### CPU mode
@@ -407,8 +406,8 @@ ALL GENRE PREDICTIONS (top 10):
   ...
 
 MOODS (passed threshold - 2 total):
-• energetic: 2.34%
-• dark: 1.87%
+  • energetic: 2.34%
+  • dark: 1.87%
 
 ## 🎓 Understanding the Models
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ source venv/bin/activate
 # 3. Install dependencies
 pip install essentia-tensorflow mutagen numpy
 
-# 4. Download ML models (~87MB)
+# 4. Download ML models (~87MB) (Only required for a native run)
 bash download_models.sh
 ```
 
@@ -103,6 +103,7 @@ You'll be prompted for:
 **Recommendation:** Run in dry-run mode first to preview results!
 
 ---
+
 ## 🐳 Docker
 
 ### CPU mode
@@ -162,22 +163,22 @@ python tag_music.py /path/to/music --auto --dry-run
 
 ### CLI Arguments Reference
 
-| Argument | Short | Description | Default |
-|----------|-------|-------------|---------|
-| `--auto` | `-a` | Non-interactive mode | - |
-| `--single-file` | `-f` | Process single file | - |
-| `--genres N` | `-g` | Number of genres | 3 |
-| `--genre-threshold PCT` | `-gt` | Genre confidence % | 15 |
-| `--genre-format STYLE` | `-gf` | Format style | parent_child |
-| `--no-genres` | - | Disable genre analysis | - |
-| `--no-moods` | - | Disable mood analysis | - |
-| `--mood-threshold PCT` | `-mt` | Mood confidence % | 0.5 |
-| `--dry-run` | `-d` | Don't write tags | - |
-| `--overwrite` | `-o` | Overwrite existing tags | - |
-| `--quiet` | `-q` | Minimal output | - |
-| `--log-dir DIR` | - | Log file directory | ./ |
-| `--model-dir DIR` | - | Essentia models directory | ~/essentia_models |
-| `--library DIR` | - | Set & save default library path | - |
+| Argument                | Short | Description                                                                 | Default           |
+|-------------------------|-------|-----------------------------------------------------------------------------|-------------------|
+| `--auto`                | `-a`  | Non-interactive mode                                                        | -                 |
+| `--single-file`         | `-f`  | Process single file                                                         | -                 |
+| `--genres N`            | `-g`  | Number of genres                                                            | 3                 |
+| `--genre-threshold PCT` | `-gt` | Genre confidence %                                                          | 15                |
+| `--genre-format STYLE`  | `-gf` | Format style (`parent_child`, `child_parent`, `child_only`, `raw`, `split`) | parent_child      |
+| `--no-genres`           | -     | Disable genre analysis                                                      | -                 |
+| `--no-moods`            | -     | Disable mood analysis                                                       | -                 |
+| `--mood-threshold PCT`  | `-mt` | Mood confidence %                                                           | 0.5               |
+| `--dry-run`             | `-d`  | Don't write tags                                                            | -                 |
+| `--overwrite`           | `-o`  | Overwrite existing tags                                                     | -                 |
+| `--quiet`               | `-q`  | Minimal output                                                              | -                 |
+| `--log-dir DIR`         | -     | Log file directory                                                          | ./                |
+| `--model-dir DIR`       | -     | Essentia models directory                                                   | ~/essentia_models |
+| `--library DIR`         | -     | Set & save default library path                                             | -                 |
 
 > **Note:** `--no-genres` and `--no-moods` cannot be used together — at least one analysis type must be enabled.
 
@@ -213,11 +214,11 @@ The first setting lets you define (or update) a **default music library root pat
 
 Once set, every subsequent run begins with a path selection menu:
 
-| Option | Description |
-|--------|-------------|
-| **1. Scan entire library** (default) | Recursively scan from the library root |
-| **2. Browse & select a folder** | Open the interactive folder browser to pick a sub-folder |
-| **3. Enter a custom path** | Type a path manually (original behaviour) |
+| Option                               | Description                                              |
+|--------------------------------------|----------------------------------------------------------|
+| **1. Scan entire library** (default) | Recursively scan from the library root                   |
+| **2. Browse & select a folder**      | Open the interactive folder browser to pick a sub-folder |
+| **3. Enter a custom path**           | Type a path manually (original behaviour)                |
 
 #### Interactive Folder Browser
 
@@ -235,22 +236,22 @@ Option 2 opens a full-screen CLI folder navigator:
      📁 [1996] The Don Killuminati
 ```
 
-| Key | Action |
-|-----|--------|
-| ↑ / ↓ | Move selection up/down |
-| Enter | Select folder or navigate into it |
-| Backspace | Go up one directory |
-| q | Cancel and return to path selection |
+| Key       | Action                              |
+|-----------|-------------------------------------|
+| ↑ / ↓     | Move selection up/down              |
+| Enter     | Select folder or navigate into it   |
+| Backspace | Go up one directory                 |
+| q         | Cancel and return to path selection |
 
 #### Analysis Mode
 
 Choose what to analyse for each run:
 
-| Option | Description |
-|--------|-------------|
-| **1. Both** (default) | Analyse and write both genre and mood tags |
-| **2. Genres only** | Run only the genre model; skip mood analysis entirely |
-| **3. Moods only** | Run only the mood model; skip genre analysis entirely |
+| Option                | Description                                           |
+|-----------------------|-------------------------------------------------------|
+| **1. Both** (default) | Analyse and write both genre and mood tags            |
+| **2. Genres only**    | Run only the genre model; skip mood analysis entirely |
+| **3. Moods only**     | Run only the mood model; skip genre analysis entirely |
 
 Only the models that are needed are loaded, saving memory and time when running in a single-mode.
 
@@ -259,10 +260,11 @@ Only the models that are needed are loaded, saving memory and time when running 
 - **Number of genres** (1-10) - How many genre tags per song
 - **Confidence threshold** (1-50%) - Minimum prediction confidence
 - **Format style**:
-  - `Rock - Alternative Rock` (parent - child) ← default
-  - `Alternative Rock - Rock` (child - parent)
-  - `Alternative Rock` (child only)
-  - `Rock---Alternative Rock` (raw)
+    - `Rock - Alternative Rock` (parent - child) ← default
+    - `Alternative Rock - Rock` (child - parent)
+    - `Alternative Rock` (child only)
+    - `Rock---Alternative Rock` (raw)
+    - `Rock` + `Alternative Rock` (split) formats parent and child as separate genres, deduplicated
 
 #### Mood Settings *(shown when mode is Both or Moods only)*
 
@@ -338,11 +340,11 @@ Understanding confidence scores:
 
 ### Tag Formatting Examples
 
-| Raw Prediction            | parent_child              | child_parent              | child_only         |
-| ------------------------- | ------------------------- | ------------------------- | ------------------ |
-| `Rock---Alternative Rock` | `Rock - Alternative Rock` | `Alternative Rock - Rock` | `Alternative Rock` |
-| `Hip-Hop---Gangsta`       | `Hip-Hop - Gangsta`       | `Gangsta - Hip-Hop`       | `Gangsta`          |
-| `Electronic---Techno`     | `Electronic - Techno`     | `Techno - Electronic`     | `Techno`           |
+| Raw Prediction            | parent_child              | child_parent              | child_only         | split                       |
+|---------------------------|---------------------------|---------------------------|--------------------|-----------------------------|
+| `Rock---Alternative Rock` | `Rock - Alternative Rock` | `Alternative Rock - Rock` | `Alternative Rock` | `Rock` + `Alternative Rock` |
+| `Hip-Hop---Gangsta`       | `Hip-Hop - Gangsta`       | `Gangsta - Hip-Hop`       | `Gangsta`          | `Hip-Hop` + `Gangsta`       |
+| `Electronic---Techno`     | `Electronic - Techno`     | `Techno - Electronic`     | `Techno`           | `Electronic` + `Techno`     |
 
 ---
 
@@ -405,8 +407,8 @@ ALL GENRE PREDICTIONS (top 10):
   ...
 
 MOODS (passed threshold - 2 total):
-  • energetic: 2.34%
-  • dark: 1.87%
+• energetic: 2.34%
+• dark: 1.87%
 
 ## 🎓 Understanding the Models
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ You'll be prompted for:
 
 ### CPU mode
 
+If you plan to build the image multiple times, like for development, you can run `bash download_models.sh` 
+to pre-download the models. The docker build will pick them from there, instead of downloading them again.
+
 ```bash
 # Build the image
 docker compose build essentia-tagger

--- a/download_models.sh
+++ b/download_models.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-MODEL_DIR="${HOME}/essentia_models"
+MODEL_DIR="$(cd "$(dirname "$0")" && pwd)/essentia_models"
 
 echo "🎵 Essentia Model Downloader"
 echo "================================"
@@ -19,17 +19,17 @@ cd "${MODEL_DIR}"
 
 # Download embedding model (required)
 echo "📦 Downloading embedding model..."
-wget -q --show-progress https://essentia.upf.edu/models/music-style-classification/discogs-effnet/discogs-effnet-bs64-1.pb
+wget -nc -q --show-progress https://essentia.upf.edu/models/music-style-classification/discogs-effnet/discogs-effnet-bs64-1.pb
 
 # Download genre classifier
 echo "📦 Downloading genre classifier (Discogs 400)..."
-wget -q --show-progress https://essentia.upf.edu/models/classification-heads/genre_discogs400/genre_discogs400-discogs-effnet-1.pb
-wget -q --show-progress https://essentia.upf.edu/models/classification-heads/genre_discogs400/genre_discogs400-discogs-effnet-1.json
+wget -nc -q --show-progress https://essentia.upf.edu/models/classification-heads/genre_discogs400/genre_discogs400-discogs-effnet-1.pb
+wget -nc -q --show-progress https://essentia.upf.edu/models/classification-heads/genre_discogs400/genre_discogs400-discogs-effnet-1.json
 
 # Download mood classifier
 echo "📦 Downloading mood classifier..."
-wget -q --show-progress https://essentia.upf.edu/models/classification-heads/mtg_jamendo_moodtheme/mtg_jamendo_moodtheme-discogs-effnet-1.pb
-wget -q --show-progress https://essentia.upf.edu/models/classification-heads/mtg_jamendo_moodtheme/mtg_jamendo_moodtheme-discogs-effnet-1.json
+wget -nc -q --show-progress https://essentia.upf.edu/models/classification-heads/mtg_jamendo_moodtheme/mtg_jamendo_moodtheme-discogs-effnet-1.pb
+wget -nc -q --show-progress https://essentia.upf.edu/models/classification-heads/mtg_jamendo_moodtheme/mtg_jamendo_moodtheme-discogs-effnet-1.json
 
 echo ""
 echo "✅ Download complete!"

--- a/tag_music.py
+++ b/tag_music.py
@@ -102,6 +102,43 @@ def format_genre_tag(raw_genre, style='parent_child'):
     return raw_genre
 
 
+def build_genre_list(raw_genres, style):
+    """
+    Build a deduplicated list of formatted genre strings.
+
+    For 'split' style: splits each 'Parent---Child' label into separate parent
+    and child entries, preserving insertion order with no duplicates.
+    For all other styles: calls format_genre_tag per label and deduplicates.
+
+    Args:
+        raw_genres: List of dicts with 'label' key (from genre prediction)
+        style: Genre format style (see format_genre_tag, plus 'split')
+
+    Returns:
+        List of unique genre strings
+    """
+    seen = []
+    if style == 'split':
+        for g in raw_genres:
+            label = g['label']
+            if '---' in label:
+                parts = label.split('---')
+                parent = parts[0].strip()
+                child = parts[1].strip() if len(parts) > 1 else ''
+                for value in ((parent, child) if child else (parent,)):
+                    if value not in seen:
+                        seen.append(value)
+            else:
+                if label not in seen:
+                    seen.append(label)
+    else:
+        for g in raw_genres:
+            formatted = format_genre_tag(g['label'], style=style)
+            if formatted not in seen:
+                seen.append(formatted)
+    return seen
+
+
 def format_mood_tag(raw_mood):
     """
     Format mood tags for better readability
@@ -417,10 +454,7 @@ class EssentiaAnalyzer:
                 results['genres'] = genres
                 
                 # Format genres for tag writing
-                results['formatted_genres'] = [
-                    format_genre_tag(g['label'], style=self.config.genre_format) 
-                    for g in genres
-                ]
+                results['formatted_genres'] = build_genre_list(genres, self.config.genre_format)
                 
                 # Store all genre activations for logging
                 all_top_indices = np.argsort(genre_activations)[::-1][:10]
@@ -542,9 +576,8 @@ class TagWriter:
         
         if self.config.enable_genres and results.get('formatted_genres'):
             if self.config.overwrite_existing or 'GENRE' not in audio:
-                genre_str = '; '.join(results['formatted_genres'])
-                audio['GENRE'] = genre_str
-                tags_written.append(f"GENRE={genre_str}")
+                audio['GENRE'] = results['formatted_genres']
+                tags_written.append(f"GENRE={'; '.join(results['formatted_genres'])}")
                 
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
@@ -594,9 +627,8 @@ class TagWriter:
         if self.config.enable_genres and results.get('formatted_genres'):
             has_existing = '\xa9gen' in audio.tags if audio.tags else False
             if self.config.overwrite_existing or not has_existing:
-                genre_str = '; '.join(results['formatted_genres'])
-                audio['\xa9gen'] = [genre_str]
-                tags_written.append(f"genre={genre_str}")
+                audio['\xa9gen'] = results['formatted_genres']
+                tags_written.append(f"genre={'; '.join(results['formatted_genres'])}")
                 
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
@@ -633,9 +665,8 @@ class TagWriter:
         if self.config.enable_genres and results.get('formatted_genres'):
             has_existing = 'WM/Genre' in audio if audio.tags else False
             if self.config.overwrite_existing or not has_existing:
-                genre_str = '; '.join(results['formatted_genres'])
-                audio['WM/Genre'] = genre_str
-                tags_written.append(f"WM/Genre={genre_str}")
+                audio['WM/Genre'] = results['formatted_genres']
+                tags_written.append(f"WM/Genre={'; '.join(results['formatted_genres'])}")
                 
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
@@ -686,10 +717,9 @@ class TagWriter:
         if self.config.enable_genres and results.get('formatted_genres'):
             has_existing_genre = bool(tags.getall('TCON'))
             if self.config.overwrite_existing or not has_existing_genre:
-                genre_str = '; '.join(results['formatted_genres'])
                 tags.delall('TCON')
-                tags.add(TCON(encoding=3, text=genre_str))
-                tags_written.append(f"TCON={genre_str}")
+                tags.add(TCON(encoding=3, text=results['formatted_genres']))
+                tags_written.append(f"TCON={'; '.join(results['formatted_genres'])}")
                 
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
@@ -736,9 +766,8 @@ class TagWriter:
         if self.config.enable_genres and results.get('formatted_genres'):
             has_existing = 'Genre' in audio.tags
             if self.config.overwrite_existing or not has_existing:
-                genre_str = '; '.join(results['formatted_genres'])
-                audio.tags['Genre'] = genre_str
-                tags_written.append(f"Genre={genre_str}")
+                audio.tags['Genre'] = results['formatted_genres']
+                tags_written.append(f"Genre={'; '.join(results['formatted_genres'])}")
                 
                 if self.config.write_confidence_tags and results.get('genres'):
                     genre_details = [f"{g['label']}: {g['confidence']:.2%}" for g in results['genres']]
@@ -915,9 +944,7 @@ def _worker_process_file(args):
                 })
 
             results['genres'] = genres
-            results['formatted_genres'] = [
-                format_genre_tag(g['label'], style=genre_format) for g in genres
-            ]
+            results['formatted_genres'] = build_genre_list(genres, genre_format)
             all_top = np.argsort(genre_activations)[::-1][:10]
             results['all_genres_debug'] = [
                 (genre_labels[idx], float(genre_activations[idx])) for idx in all_top
@@ -1571,12 +1598,14 @@ def configure_settings():
         print("   • 2 = 'Alternative Rock - Rock' (child - parent)")
         print("   • 3 = 'Alternative Rock' (child only)")
         print("   • 4 = 'Rock---Alternative Rock' (raw/no formatting)")
-        format_choice = get_int_input("Genre format", default=1, min_val=1, max_val=4)
+        print("   • 5 = parent + child as separate multi-value tags (split)")
+        format_choice = get_int_input("Genre format", default=1, min_val=1, max_val=5)
         format_map = {
             1: 'parent_child',
             2: 'child_parent',
             3: 'child_only',
-            4: 'raw'
+            4: 'raw',
+            5: 'split'
         }
         config.genre_format = format_map[format_choice]
     
@@ -1766,9 +1795,9 @@ Genre format styles:
     
     parser.add_argument(
         '--genre-format', '-gf',
-        choices=['parent_child', 'child_parent', 'child_only', 'raw'],
+        choices=['parent_child', 'child_parent', 'child_only', 'raw', 'split'],
         default='parent_child',
-        help='Genre tag format style (default: parent_child)'
+        help='Genre tag format style (default: parent_child). split writes parent and child as separate multi-value tags, deduplicated'
     )
     
     # Analysis mode settings


### PR DESCRIPTION
Thanks for this great tool.
However, I didn't like the existing genre formatting options. I like to keep my genres separate and not in a parent/child format. And the child_only is missing the parent, even though often the parent would be more important than the child tag.  
This MR adds the capability to add them both, as separate tags.  

during building the container I noticed it will always try to download the models. This also fixes this by using the downloaded models from the `essentia_models` directory if they are already downloaded. I also was so free to move the download directory to the current repo dir, because I don't think programs should just create new directories in someones home.  
If you don't like the change I could remove it again, or just move it to a separate merge request.